### PR TITLE
Fixing issue #5

### DIFF
--- a/IPA/PatchContext.cs
+++ b/IPA/PatchContext.cs
@@ -49,7 +49,7 @@ namespace IPA
             context.ProjectName = Path.GetFileNameWithoutExtension(context.Executable);
             context.DataPathDst = Path.Combine(context.ProjectRoot, context.ProjectName + "_Data");
             context.ManagedPath = Path.Combine(context.DataPathDst, "Managed");
-            context.EngineFile = Path.Combine(context.ManagedPath, "UnityEngine.dll");
+            context.EngineFile = Path.Combine(context.ManagedPath, (File.Exists(Path.Combine(context.ManagedPath, "UnityEngine.CoreModule.dll")) ? "UnityEngine.CoreModule.dll" : "UnityEngine.dll"));
             context.AssemblyFile = Path.Combine(context.ManagedPath, "Assembly-Csharp.dll");
             context.BackupPath = Path.Combine(Path.Combine(context.IPARoot, "Backups"), context.ProjectName);
             string shortcutName = string.Format("{0} (Patch & Launch)", context.ProjectName);


### PR DESCRIPTION
It patches UnityEngine.CoreModule.dll if found, otherwise old functionality remains and UnityEngine.dll is patched. See Issue #5 I created.