### PR TITLE
Create Default Folder to save ini to

### DIFF
--- a/IllusionPlugin/ModPrefs.cs
+++ b/IllusionPlugin/ModPrefs.cs
@@ -17,6 +17,7 @@ namespace IllusionPlugin
             {
                 if (_instance == null)
                 {
+                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(Environment.CurrentDirectory, "UserData/"));
                     _instance = new IniFile(Path.Combine(Environment.CurrentDirectory, "UserData/modprefs.ini"));
                 }
                 return _instance;


### PR DESCRIPTION
If the /UserData/ folder doesn't exist, the methods of this file fails to work. Creating the folder before hand prevents this issue.