### PR TITLE
Fix missing entry handler for UnityEngine.dll on newer versions

### DIFF
--- a/IPA/PatchContext.cs
+++ b/IPA/PatchContext.cs
@@ -49,7 +49,7 @@ namespace IPA
             context.ProjectName = Path.GetFileNameWithoutExtension(context.Executable);
             context.DataPathDst = Path.Combine(context.ProjectRoot, context.ProjectName + "_Data");
             context.ManagedPath = Path.Combine(context.DataPathDst, "Managed");
-            context.EngineFile =  DetermineEngineFile(context.ManagedPath, "UnityEngine.dll", "UnityEngine.CoreModule.dll");
+            context.EngineFile =  DetermineEngineFile(context.ManagedPath, "UnityEngine.CoreModule.dll", "UnityEngine.dll");
             context.AssemblyFile = Path.Combine(context.ManagedPath, "Assembly-Csharp.dll");
             context.BackupPath = Path.Combine(Path.Combine(context.IPARoot, "Backups"), context.ProjectName);
             context.ShortcutPath = Path.Combine(context.ProjectRoot, $"{context.ProjectName} (Patch & Launch)") + ".lnk";


### PR DESCRIPTION
Fixes Eusth/IPA#5.

I'm not too familiar with Unity's architecture, or what IPA exactly does, but I feel like the parameters for `DetermineEngineFile` were the wrong way around - it looked in `UnityEngine.dll` first, and then in `UnityEngine.CoreModule.dll`. The two types that IPA is looking for, however, reside usually inside `UnityEngine.CoreModule.dll` in newer Unity applications.

Using this fix, IPA was able to successfully patch the game again.